### PR TITLE
Add support for fine grained tokens

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,15 +16,26 @@ source /home/docker/.ACCESS_TOKEN
 # ACCESS_TOKEN="******************"
 
 # REGISTRATION TOKEN
-
+echo $ACCES
 # Obtain the REG_TOKEN via post request to the github api
-REG_TOKEN=$(curl -sX POST -H "Authorization: token ${ACCESS_TOKEN}" https://api.github.com/repos/${ORGANIZATION}/actions/runners/registration-token | jq .token --raw-output)
+if [[ $ACCESS_TOKEN = *"github_"* ]]
+then
+    ## If using instead fine-grained tokens:
+    REG_TOKEN=$(curl -L \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/orgs/${ORGANIZATION}/actions/runners/registration-token | jq .token --raw-output)
+else
+    REG_TOKEN=$(curl -sX POST -H "AuthorizaTion: token ${ACCESS_TOKEN}" https://api.github.com/repos/${ORGANIZATION}/actions/runners/registration-token | jq .token --raw-output)
+fi
+
 # Alternatively the REG_TOKEN can be written explicitly here
 # !WARNING: DO NOT COMMIT A PLAIN TOKEN!
 # REG_TOKEN="**************"
 
 # MAIN SCRIPT
-
 cd /home/docker/actions-runner
 
 ./config.sh --url https://github.com/${ORGANIZATION} --token ${REG_TOKEN}

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,6 @@ source /home/docker/.ACCESS_TOKEN
 # ACCESS_TOKEN="******************"
 
 # REGISTRATION TOKEN
-echo $ACCES
 # Obtain the REG_TOKEN via post request to the github api
 if [[ $ACCESS_TOKEN = *"github_"* ]]
 then
@@ -38,7 +37,7 @@ fi
 # MAIN SCRIPT
 cd /home/docker/actions-runner
 
-./config.sh --url https://github.com/${ORGANIZATION} --token ${REG_TOKEN}
+./config.sh --url https://github.com/${ORGANIZATION} --token ${REG_TOKEN} --labels "gpu"
 
 cleanup() {
     echo "Removing runner..."


### PR DESCRIPTION
The syntax changes a bit for fine-grained tokens (if I understood the docs correctly)

It might also be that it works only for my particular use case ^^U but it seems that fine grained tokens start with `github_<whatever>` so it looks like a safe check.

With `ACCESS_TOKEN` the token as usual and `ORGANIZATION` just `Amps-GPU` in our case.